### PR TITLE
Add model selection for tutor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # ai4eduagent
+
+This repository contains a minimal interactive Python tutor designed for middle school students.
+
+## Requirements
+- Python 3.10+
+- `google-adk` and `litellm` packages
+- An API key for your chosen model provider (OpenAI, DeepSeek, or Google Gemini)
+
+Install dependencies:
+```bash
+pip install google-adk litellm
+```
+
+## Usage
+Set the appropriate API key and model, then run the tutor:
+```bash
+export OPENAI_API_KEY=your-key-here  # or DEEPSEEK_API_KEY / GOOGLE_API_KEY
+export MODEL_NAME=gpt-3.5-turbo      # or deepseek-chat / gemini-pro
+python python_tutor.py
+```
+
+The tutor interacts in Chinese, guiding students step by step to learn Python. Type `exit` or `quit` to leave the conversation.

--- a/python_tutor.py
+++ b/python_tutor.py
@@ -1,0 +1,62 @@
+import os
+import asyncio
+from google.generativeai import types
+from google.adk.agents.llm_agent import LlmAgent
+from google.adk.artifacts import InMemoryArtifactService
+from google.adk.sessions.in_memory_session_service import InMemorySessionService
+from google.adk.auth.credential_service.in_memory_credential_service import InMemoryCredentialService
+from google.adk.runners import Runner
+
+SYSTEM_PROMPT = (
+    "你是一个友好的 Python 编程辅导老师，面对的学生是中学生初学者。"
+    "你的目标是引导学生自己完成任务。首先通过启发式提问和给出小提示，"
+    "逐步帮助学生思考；如果学生多次尝试仍有困难，再提供更详细的提示，"
+    "最后给出完整示例并附上清晰易懂的解释。请始终使用中文回答，语言要简洁、鼓励。"
+)
+
+
+async def main() -> None:
+    model_name = os.environ.get("MODEL_NAME", "gpt-3.5-turbo")
+    root_agent = LlmAgent(
+        name="python_tutor",
+        instruction=SYSTEM_PROMPT,
+        model=model_name,
+    )
+    artifact_service = InMemoryArtifactService()
+    session_service = InMemorySessionService()
+    credential_service = InMemoryCredentialService()
+
+    user_id = "student"
+    session = await session_service.create_session(
+        app_name="python_tutor", user_id=user_id
+    )
+    runner = Runner(
+        app_name="python_tutor",
+        agent=root_agent,
+        artifact_service=artifact_service,
+        session_service=session_service,
+        credential_service=credential_service,
+    )
+
+    print("欢迎使用 Python 自学助手，输入 exit 或 quit 退出。")
+    while True:
+        try:
+            user_input = input("你: ")
+            if user_input.strip().lower() in {"exit", "quit"}:
+                print("再见！")
+                break
+            content = types.Content(role="user", parts=[types.Part(text=user_input)])
+            async for event in runner.run_async(
+                user_id=user_id, session_id=session.id, new_message=content
+            ):
+                if event.content and event.content.parts:
+                    text = "".join(part.text or "" for part in event.content.parts)
+                    if text:
+                        print(f"{event.author}: {text}")
+        except KeyboardInterrupt:
+            print("\n再见！")
+            break
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- allow selecting LLM model via `MODEL_NAME`
- document DeepSeek and Gemini support in README

## Testing
- `python -m py_compile python_tutor.py`
- `OPENAI_API_KEY=fake MODEL_NAME=gpt-3.5-turbo python python_tutor.py <<'EOF'
exit
EOF`


------
https://chatgpt.com/codex/tasks/task_b_686e10d40f888329b12651befc35f89b