### PR TITLE
Add DeepSeek and Gemini API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ pip install google-adk litellm
 ## Usage
 Set the appropriate API key and model, then run the tutor:
 ```bash
-export OPENAI_API_KEY=your-key-here  # or DEEPSEEK_API_KEY / GOOGLE_API_KEY
+# For OpenAI models
+export OPENAI_API_KEY=your-openai-key
+# For DeepSeek models
+export DEEPSEEK_API_KEY=your-deepseek-key
+# For Google Gemini models
+export GOOGLE_API_KEY=your-gemini-key
+
 export MODEL_NAME=gpt-3.5-turbo      # or deepseek-chat / gemini-pro
 python python_tutor.py
 ```

--- a/python_tutor.py
+++ b/python_tutor.py
@@ -3,9 +3,15 @@ import asyncio
 from google.generativeai import types
 from google.adk.agents.llm_agent import LlmAgent
 from google.adk.artifacts import InMemoryArtifactService
-from google.adk.sessions.in_memory_session_service import InMemorySessionService
-from google.adk.auth.credential_service.in_memory_credential_service import InMemoryCredentialService
+from google.adk.sessions.in_memory_session_service import (
+    InMemorySessionService,
+)
+from google.adk.auth.credential_service.in_memory_credential_service import (
+    InMemoryCredentialService,
+)
 from google.adk.runners import Runner
+from google.adk.models.google_llm import Gemini
+from google.adk.models.lite_llm import LiteLlm
 
 SYSTEM_PROMPT = (
     "你是一个友好的 Python 编程辅导老师，面对的学生是中学生初学者。"
@@ -17,10 +23,14 @@ SYSTEM_PROMPT = (
 
 async def main() -> None:
     model_name = os.environ.get("MODEL_NAME", "gpt-3.5-turbo")
+    if model_name.startswith("gemini"):
+        llm_model = Gemini(model=model_name)
+    else:
+        llm_model = LiteLlm(model=model_name)
     root_agent = LlmAgent(
         name="python_tutor",
         instruction=SYSTEM_PROMPT,
-        model=model_name,
+        model=llm_model,
     )
     artifact_service = InMemoryArtifactService()
     session_service = InMemorySessionService()


### PR DESCRIPTION
## Summary
- revert direct litellm usage and keep `google-adk`
- integrate `LiteLlm` for OpenAI/DeepSeek models
- document separate API variables for each provider

## Testing
- `python -m py_compile python_tutor.py`


------
https://chatgpt.com/codex/tasks/task_b_686e17ea86cc83299b6752b940e36b1e